### PR TITLE
Shifting labels to enable learning next token prediction

### DIFF
--- a/perceiver_ar_pytorch/perceiver_ar_pytorch.py
+++ b/perceiver_ar_pytorch/perceiver_ar_pytorch.py
@@ -303,6 +303,8 @@ class PerceiverAR(nn.Module):
 
         if not exists(labels):
             return logits
+        
+        #shift the labels to the right to enable generative training:
 
-        labels = labels[:, self.cross_attn_seq_len:]
-        return F.cross_entropy(rearrange(logits, 'b n c -> b c n'), labels, ignore_index = 0)
+        shifted_labels = torch.cat(labels[:, self.cross_attn_seq_len+1:],torch.zeros(labels.shape[0],1).to(device), dim=1)
+        return F.cross_entropy(rearrange(logits, 'b n c -> b c n'), shifted_labels, ignore_index = 0)


### PR DESCRIPTION
Dear lucidrains,
Many thanks for your amazing contribution to the community.
In the following pull request I modified the code so that the labels to the right during training before calculating the loss to enable next-token prediction (otherwise, the loss is calculated for the token, which leads to learning the trivial, current token)

L

